### PR TITLE
Fixing bad syntax condition in SH

### DIFF
--- a/receive.sh
+++ b/receive.sh
@@ -50,7 +50,7 @@ if [ -n "$CONSUMER_KEY" ]; then
 	fi
 fi
 
-if [ "$DELETE_AUDIO" = true ];
+if [ "$DELETE_AUDIO" = true ]; then
     rm "${NOAA_AUDIO}/audio/${3}.wav"
 else
     # Move the audio from the ram fs to the SD Card

--- a/receive_meteor.sh
+++ b/receive_meteor.sh
@@ -38,7 +38,7 @@ sox "${METEOR_OUTPUT}/audio/${3}.wav" "${METEOR_OUTPUT}/${3}.wav" gain -n
 log "Demodulation in progress (QPSK)" "INFO"
 meteor_demod -B -o "${METEOR_OUTPUT}/${3}.qpsk" "${METEOR_OUTPUT}/${3}.wav"
 
-if [ "$DELETE_AUDIO" = true ];
+if [ "$DELETE_AUDIO" = true ]; then
     rm "${METEOR_OUTPUT}/audio/${3}.wav"
     rm "${METEOR_OUTPUT}/${3}.wav"
 fi


### PR DESCRIPTION
### Description
After tests, I remarked that some commands aren't ran. This is due to a missing `then` symbol in `if` conditions in `sh`.

### Fix
I only added the missing symbol `then`, in two places: `receive_meteor.sh` and `receive.sh`