### PR TITLE
Changed JPG to PNG, invert nighttime Meteor M2 images and fixed timezone issues

### DIFF
--- a/receive.sh
+++ b/receive.sh
@@ -42,17 +42,19 @@ log "Bulding pass map" "INFO"
 /usr/local/bin/wxmap -T "${1}" -H "${4}" -p 0 -l 0 -o "${PASS_START}" "${NOAA_HOME}/map/${3}-map.png"
 for i in $ENHANCEMENTS; do
 	log "Decoding image" "INFO"
-	/usr/local/bin/wxtoimg -o -m "${NOAA_HOME}/map/${3}-map.png" -e "$i" "${RAMFS_AUDIO}/audio/${3}.wav" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-$i.jpg"
-	/usr/bin/convert -quality 90 -format jpg "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-$i.jpg" -undercolor black -fill yellow -pointsize 18 -annotate +20+20 "${1} $i ${START_DATE}" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-$i.jpg"
+	/usr/local/bin/wxtoimg -o -m "${NOAA_HOME}/map/${3}-map.png" -e "$i" "${RAMFS_AUDIO}/audio/${3}.wav" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-$i.png"
+	/usr/bin/convert "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-$i.png" -undercolor black -fill yellow -pointsize 18 -annotate +20+20 "${1} $i ${START_DATE} Elevation: $7°" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-$i.png"
 done
 if [ -n "$CONSUMER_KEY" ]; then
 	log "Posting to Twitter" "INFO"
 	if [ "${SUN_ELEV}" -gt "${SUN_MIN_ELEV}" ]; then
-		python3 "${NOAA_HOME}/post.py" "$1 ${START_DATE}" "$7" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-MCIR-precip.jpg" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-MSA-precip.jpg" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-HVC-precip.jpg" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-HVCT-precip.jpg" 
+		python3 "${NOAA_HOME}/post.py" "$1 ${START_DATE}" "$7" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-MCIR-precip.png" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-MSA-precip.png" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-HVC-precip.png" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-HVCT-precip.png" 
 	else
-		python3 "${NOAA_HOME}/post.py" "$1 ${START_DATE}" "$7" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-MCIR-precip.jpg" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-MCIR.jpg"
+		python3 "${NOAA_HOME}/post.py" "$1 ${START_DATE}" "$7" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-MCIR-precip.png" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/$3-MCIR.png"
 	fi
 fi
+
+rm "${NOAA_HOME}/map/${3}-map.png"
 
 if [ "$DELETE_AUDIO" = true ]; then
 	log "Deleting audio files" "INFO"

--- a/receive_meteor.sh
+++ b/receive_meteor.sh
@@ -54,23 +54,29 @@ if [ -f "${METEOR_OUTPUT}/${3}.dec" ]; then
 
     if [ "${SUN_ELEV}" -lt "${SUN_MIN_ELEV}" ]; then
         log "I got a successful ${3}.dec file. Decoding APID 68" "INFO"
-        medet_arm "${METEOR_OUTPUT}/${3}.dec" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122" -r 68 -g 68 -b 68 -d
-        /usr/bin/convert -rotate 180 "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.bmp" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.bmp"
+        medet_arm "${METEOR_OUTPUT}/${3}.dec" "${METEOR_OUTPUT}/${3}-122" -r 68 -g 68 -b 68 -d
+        convert "${METEOR_OUTPUT}/${3}-122.bmp" -channel RGB -negate "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.png"
     else
         log "I got a successful ${3}.dec file. Creating false color image" "INFO"
-        medet_arm "${METEOR_OUTPUT}/${3}.dec" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122" -r 65 -g 65 -b 64 -d
+        medet_arm "${METEOR_OUTPUT}/${3}.dec" "${METEOR_OUTPUT}/${3}-122" -r 65 -g 65 -b 64 -d
+        convert "${METEOR_OUTPUT}/${3}-122.bmp" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.png"
     fi
-
     log "Rectifying image to adjust aspect ratio" "INFO"
-    python3 "${NOAA_HOME}/rectify.py" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.bmp"
-    convert "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified.jpg" -channel rgb -normalize "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified.jpg"
-    rm "${METEOR_OUTPUT}/${3}.bmp"
-    rm "${METEOR_OUTPUT}/${3}-122.bmp"
-
+    python3 "${NOAA_HOME}/rectify.py" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.png"
+    convert "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified.png" -undercolor black -fill yellow -pointsize 18 -annotate +20+20 "${1} ${START_DATE} Elevation: $7Â°" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified-text.png"
     if [ -n "$CONSUMER_KEY" ]; then
         log "Posting to Twitter" "INFO"
-        python3 "${NOAA_HOME}/post.py" "$1 EXPERIMENTAL ${START_DATE} Resolución completa: http://weather.reyni.co/image/${FOLDER_DATE}/${3}-122-rectified.jpg" "$7" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified.jpg"
+        python3 "${NOAA_HOME}/post.py" "$1 ${START_DATE}" "$7Â°" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified-text.png"
     fi
+    rm "${METEOR_OUTPUT}/${3}.bmp"
+    rm "${METEOR_OUTPUT}/${3}-122.bmp"
+    rm "${METEOR_OUTPUT}/${3}-122.png"
+    rm "${METEOR_OUTPUT}/${3}.dec"
+    rm "${METEOR_OUTPUT}/${3}-122.png"
+    rm "${METEOR_OUTPUT}/${3}-122-rectified.png"
+    rm "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.png"
+    rm "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified.png"
+    #rm "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified-text.png"
 else
     log "Decoding failed, either a bad pass/low SNR or a software problem" "ERROR"
 fi

--- a/receive_meteor.sh
+++ b/receive_meteor.sh
@@ -66,7 +66,7 @@ if [ -f "${METEOR_OUTPUT}/${3}.dec" ]; then
     convert "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified.png" -undercolor black -fill yellow -pointsize 18 -annotate +20+20 "${1} ${START_DATE} Elevation: $7Â°" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified-text.png"
     if [ -n "$CONSUMER_KEY" ]; then
         log "Posting to Twitter" "INFO"
-        python3 "${NOAA_HOME}/post.py" "$1 ${START_DATE}" "$7Â°" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified-text.png"
+        python3 "${NOAA_HOME}/post.py" "$1 ${START_DATE}" "$7°" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified-text.png"
     fi
     rm "${METEOR_OUTPUT}/${3}.bmp"
     rm "${METEOR_OUTPUT}/${3}-122.bmp"

--- a/receive_meteor.sh
+++ b/receive_meteor.sh
@@ -66,7 +66,7 @@ if [ -f "${METEOR_OUTPUT}/${3}.dec" ]; then
     convert "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified.png" -undercolor black -fill yellow -pointsize 18 -annotate +20+20 "${1} ${START_DATE} Elevation: $7Â°" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified-text.png"
     if [ -n "$CONSUMER_KEY" ]; then
         log "Posting to Twitter" "INFO"
-        python3 "${NOAA_HOME}/post.py" "$1 ${START_DATE}" "$7°" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified-text.png"
+        python3 "${NOAA_HOME}/post.py" "$1 EXPERIMENTAL ${START_DATE} Resolución completa: http://weather.reyni.co/image/${FOLDER_DATE}/${3}-122-rectified.jpg" "$7°" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122-rectified.png"
     fi
     rm "${METEOR_OUTPUT}/${3}.bmp"
     rm "${METEOR_OUTPUT}/${3}-122.bmp"

--- a/rectify.py
+++ b/rectify.py
@@ -8,7 +8,7 @@ from math import atan,sin,cos,sqrt,tan,acos,ceil
 from PIL import Image
 
 EARTH_RADIUS = 6371.0
-SAT_HEIGHT = 822.5
+SAT_HEIGHT = 830.0
 SAT_ORBIT_RADIUS = EARTH_RADIUS + SAT_HEIGHT
 SWATH_KM = 2800.0
 THETA_C = SWATH_KM / EARTH_RADIUS
@@ -180,4 +180,4 @@ if __name__ == "__main__":
     # It's a dead pool now
     p.join()
 
-    rectified_img.save(out_fname + ".jpg", "JPEG", quality=90)
+    rectified_img.save(out_fname + ".png", "PNG")

--- a/sun.py
+++ b/sun.py
@@ -2,8 +2,8 @@
 import ephem
 import time
 import sys
-timezone = change_tz
-date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(int(sys.argv[1])+(timezone*60*60)))
+timezone = change_tz + time.localtime().tm_isdst
+date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(int(sys.argv[1])-(timezone*60*60)))
 
 obs=ephem.Observer()
 obs.lat='change_latitude'


### PR DESCRIPTION
I've changed all receive scripts and rectify.py to work exclusively with PNG instead of JPG format in order to preserve the resolution. Nighttime Meteor M2 passes are inverted in colour so that clouds remain white, and not black. Fixed issue with timezones I have had (when I input +2, program calculates sun elevation for -2 timezone).