### PR TITLE
Create directory for ISS wav file recordings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -250,6 +250,8 @@ echo "
 
 set +e
 
+sudo mkdir -p /usr/share/html/iss
+
 ### Running WXTOIMG to have the user accept the licensing agreement
 wxtoimg
 


### PR DESCRIPTION
Added `sudo mkdir -p /usr/share/html/iss` because sox couldn't save file since the directory didn't exist. This is from the log:

```/usr/bin/sox FAIL formats: can't open output file `/usr/share/html/iss/iss-20201225-094200.wav': No such file or directory```